### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/django-adminlte3/security/code-scanning/1](https://github.com/kelsoncm/django-adminlte3/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/qa_deploy.yml` at the workflow root (preferred here since there is only one job). Use least privilege: `contents: read` is the minimal safe baseline and sufficient for `actions/checkout`. This keeps behavior unchanged while preventing accidental broader token access if repo/org defaults are permissive or change later.

Concretely:
- Edit `.github/workflows/qa_deploy.yml`
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  between the `on:` trigger section and `jobs:` (or directly after `name:`/comments), so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
